### PR TITLE
Dependencies: Exclude lombok from uber-jar/fat-jar. This is also the …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Dependencies: Exclude lombok from uber-jar/fat-jar. This is also the recommended way by lombok. This reduces also size of the jar by 1 MB.